### PR TITLE
Fix a bug in "csr_to_user_dict".function, allow a special case single value indices {0} 

### DIFF
--- a/util/tool.py
+++ b/util/tool.py
@@ -60,7 +60,7 @@ def csr_to_user_dict(train_matrix):
     """
     train_dict = {}
     for idx, value in enumerate(train_matrix):
-        if any(value.indices):
+        if len(value.indices) > 0:
             train_dict[idx] = value.indices.copy().tolist()
     return train_dict
 


### PR DESCRIPTION
"csr_to_user_dict" should allow a special case single value indices {0} in a Compressed-Sparse-Row matrix, not just other non-zero element indices. An example can be viewed at https://stackoverflow.com/questions/52299420/scipy-csr-matrix-understand-indptr , in which the record is {indptr=7,data=h,indices=0}